### PR TITLE
feat: add Divider block in ContentEditor component

### DIFF
--- a/components/OtherComponents/Editor/ContentEditor/Element.tsx
+++ b/components/OtherComponents/Editor/ContentEditor/Element.tsx
@@ -6,59 +6,69 @@ import React from 'react';
 import H1 from '../Blocks/H1';
 import H2 from '../Blocks/H2';
 import Text from '../Blocks/Text';
+import DividerComp from "../Blocks/DividerComp";
 
 type Props = {
-  attributes: any;
-  children: any;
-  element: any;
+    attributes: any;
+    element: any;
+    //children есть по умолчанию в React.FC, его не нужно дополнительно указывать
 };
 
+
+
 const Element: React.FC<Props> = (props) => {
-  const { attributes, children, element } = props;
-  const style = { textAlign: element.align };
-  switch (element.type) {
-    // case 'block-quote':
-    //   return (
-    //     <blockquote style={style} {...attributes}>
-    //       {children}
-    //     </blockquote>
-    //   );
-    // case 'bulleted-list':
-    //   return (
-    //     <ul style={style} {...attributes}>
-    //       {children}
-    //     </ul>
-    //   );
-    case 'h1':
-      return (
-        <H1 style={style} attributes={attributes}>
-          {children}
-        </H1>
-      );
-    case 'h2':
-      return (
-        <H2 style={style} {...attributes}>
-          {children}
-        </H2>
-      );
-    // case 'list-item':
-    //   return (
-    //     <li style={style} {...attributes}>
-    //       {children}
-    //     </li>
-    //   );
-    // case 'numbered-list':
-    //   return (
-    //     <ol style={style} {...attributes}>
-    //       {children}
-    //     </ol>
-    //   );
-    default:
-      return (
-        <Text style={style} attributes={attributes}>
-          {children}
-        </Text>
-      );
-  }
+    const {attributes, children, element} = props;
+    const style = {textAlign: element.align};
+    const dividerStyle: object = {userSelect: 'none', width: '100%'};
+    switch (element.type) {
+        // case 'block-quote':
+        //   return (
+        //     <blockquote style={style} {...attributes}>
+        //       {children}
+        //     </blockquote>
+        //   );
+        // case 'bulleted-list':
+        //   return (
+        //     <ul style={style} {...attributes}>
+        //       {children}
+        //     </ul>
+        //   );
+        case 'h1':
+            return (
+                <H1 style={style} attributes={attributes}>
+                    {children}
+                </H1>
+            );
+        case 'h2':
+            return (
+                <H2 style={style} {...attributes}>
+                    {children}
+                </H2>
+            );
+        case 'divider':
+            return (
+                <div style={dividerStyle} contentEditable={false}>
+                    <DividerComp/>
+                </div>
+            )
+        // case 'list-item':
+        //   return (
+        //     <li style={style} {...attributes}>
+        //       {children}
+        //     </li>
+        //   );
+        // case 'numbered-list':
+        //   return (
+        //     <ol style={style} {...attributes}>
+        //       {children}
+        //     </ol>
+        //   );
+        default:
+            return (
+                <Text style={style} attributes={attributes}>
+                    {children}
+                </Text>
+            );
+    }
 };
 export default Element;


### PR DESCRIPTION
Добавил Divider в ContentEditor компонент в соответствии с задачей. Для него потребовались отдельные стили для обертки, которые запрещают его редактирование. В противном случае клик или драг приводил к ошибке в Slate.

Типизацию можно вынести в отдельную задачу, я подумаю как ее реализовать. Необходимо более подробно изучить документацию.

Большое количество изменений построчно связано с тем, что я по глупости случайно автоформатнул файл и вместо 2 табов встали 4. 