### PR TITLE
fix: fixed password errors on login form

### DIFF
--- a/components/PagesComponents/Signin/Form.tsx
+++ b/components/PagesComponents/Signin/Form.tsx
@@ -191,9 +191,14 @@ const Form: React.FC<Props> = inject('authorizationSt')(
                       fullWidth
                       label="Пароль"
                       type={showPassword ? 'text' : 'password'}
-                      helperText={`${
-                        authorizationSt.login.error === 'Wrong password' ? 'Неверный Пароль' : ''
-                      }${authorizationSt.login.error === 'Server error' ? 'Ошибка сервера' : ''}`}
+                      helperText={`
+                      ${errors?.password?.type === 'min' ? 'Минимальное число символов - 6' : ''}
+                      ${errors?.password?.type === 'max' ? 'Максимальное число символов - 100' : ''} 
+                      ${(authorizationSt.login.error === 'Wrong password' && !errors?.password?.type) 
+                        ? 'Неверный Пароль' : ''} 
+                      ${(authorizationSt.login.error === 'Server error' && !errors?.password?.type) 
+                        ? 'Ошибка сервера' : ''}
+                      `}
                       InputProps={{
                         endAdornment: (
                           <InputAdornment sx={{ mr: 0.5 }} position="end">


### PR DESCRIPTION
Исправил отсутствие ошибок о длине пароля в форме логина.
Пришлось разделить на 4 выражения, так как линтер не пропускает вложенность тернарных операторов.
Переносы в двух последних выражениях для соблюдения максимальной длины строки.