### PR TITLE
fix: fixed email errors on login form

### DIFF
--- a/components/PagesComponents/Signin/Form.tsx
+++ b/components/PagesComponents/Signin/Form.tsx
@@ -168,10 +168,11 @@ const Form: React.FC<Props> = inject('authorizationSt')(
                       type="text"
                       fullWidth
                       label="Адрес почты"
-                      helperText={
-                        authorizationSt.login.error === "User doesn't exist" &&
-                        'Пользователь не найден'
-                      }
+                      helperText={`
+                      ${authorizationSt.login.error === "User doesn't exist" 
+                        ? 'Пользователь с таким e-mail не найден' : ''}
+                      ${errors?.email?.type === 'email' ? 'Введите корректный e-mail' : ''}
+                      `}
                       {...field}
                     />
                   )}


### PR DESCRIPTION
Ошибка была связана с отсутствием сообщений об ошибках в случае, если введен неверный e-mail или пользователя с введенным e-mail не существует.

По аналогии с решением похожей ошибки для паролей немного переписал атрибут helperText у инпута e-mail. Сейчас указанные ошибки корректно отрисовываются.
